### PR TITLE
Make OSD ArtificialHorizon max pitch configurable

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1078,7 +1078,7 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	if (page->ArtificialHorizon) {
 		AttitudeActualRollGet(&tmp);
 		AttitudeActualPitchGet(&tmp1);
-		simple_artifical_horizon(tmp, tmp1, GRAPHICS_X_MIDDLE, GRAPHICS_Y_MIDDLE, 150, 150, 30);
+		simple_artifical_horizon(tmp, tmp1, GRAPHICS_X_MIDDLE, GRAPHICS_Y_MIDDLE, 150, 150, page->ArtificialHorizonMaxPitch);
 	}
 	
 	// Battery

--- a/ground/gcs/src/plugins/config/configosdwidget.cpp
+++ b/ground/gcs/src/plugins/config/configosdwidget.cpp
@@ -368,6 +368,7 @@ void ConfigOsdWidget::setupOsdPage(Ui::OsdPage * page, QWidget * page_widget, UA
     addUAVObjectToWidgetRelation(name, "ArtificialHorizon", page->ArtificialHorizonEnabled);
     page->ArtificialHorizonEnabled->setProperty(trueString.toLatin1(), "Enabled");
     page->ArtificialHorizonEnabled->setProperty(falseString.toLatin1(), "Disabled");
+    addUAVObjectToWidgetRelation(name, "ArtificialHorizonMaxPitch", page->ArtificialHorizonMaxPitch);
 
     // Battery Voltage
     addUAVObjectToWidgetRelation(name, "BatteryVolt", page->BatteryVoltEnabled);

--- a/ground/gcs/src/plugins/config/osdpage.ui
+++ b/ground/gcs/src/plugins/config/osdpage.ui
@@ -382,6 +382,30 @@
               </property>
              </widget>
             </item>
+            <item row="4" column="6">
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QLabel" name="label_35">
+                <property name="text">
+                 <string>Max Pitch:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="ArtificialHorizonMaxPitch">
+                <property name="maximum">
+                  <number>255</number>
+                </property>
+                <property name="minimum">
+                 <number>10</number>
+                </property>
+                <property name="toolTip">
+                 <string>Sets the amount of forward pitch that results in the artificial horizon displaying at the top of the screen.</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
             <item row="6" column="3">
              <widget class="QSpinBox" name="BatteryCurrentY">
               <property name="maximum">
@@ -1073,6 +1097,7 @@
   <tabstop>ArmStatusAlign</tabstop>
   <tabstop>ArmStatusFont</tabstop>
   <tabstop>ArtificialHorizonEnabled</tabstop>
+  <tabstop>ArtificialHorizonMaxPitch</tabstop>
   <tabstop>BatteryVoltEnabled</tabstop>
   <tabstop>BatteryVoltX</tabstop>
   <tabstop>BatteryVoltY</tabstop>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings.xml
@@ -21,6 +21,7 @@
 
 		
 		<field name="ArtificialHorizon" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
+		<field name="ArtificialHorizonMaxPitch" units="deg" type="uint8" elements="1" defaultvalue="30"/>
 		
 		<field name="BatteryVolt" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="BatteryVoltPosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings2.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings2.xml
@@ -21,6 +21,7 @@
 
 		
 		<field name="ArtificialHorizon" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
+		<field name="ArtificialHorizonMaxPitch" units="deg" type="uint8" elements="1" defaultvalue="30"/>
 		
 		<field name="BatteryVolt" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="BatteryVoltPosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings3.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings3.xml
@@ -21,6 +21,7 @@
 
 		
 		<field name="ArtificialHorizon" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
+		<field name="ArtificialHorizonMaxPitch" units="deg" type="uint8" elements="1" defaultvalue="30"/>
 		
 		<field name="BatteryVolt" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="BatteryVoltPosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings4.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings4.xml
@@ -21,6 +21,7 @@
 
 		
 		<field name="ArtificialHorizon" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
+		<field name="ArtificialHorizonMaxPitch" units="deg" type="uint8" elements="1" defaultvalue="30"/>
 		
 		<field name="BatteryVolt" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="BatteryVoltPosX" units="" type="int16" elements="1" defaultvalue="350"/>


### PR DESCRIPTION
Adds a new parameter ArtificialHorizonMaxPitch to the osd page
configuration and utilizes it in the OnScreenDisplay flight module.
The default value of 30 works for slower flights, but various quads
pitch further than 30 degrees forward resulting in an artificial
horizon that is off-screen.  By making it configurable pilots can
adjust it to match their flight profile, or even set different pages
with different maximum pitches depending on how they are flying at
the moment.
